### PR TITLE
Add empty state message for empty leaderboard

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -402,14 +402,15 @@ const App: React.FC = () => {
             </div>
          </div>
       )}
+
       {/* Display Empty-state message when no contributors are available */}
       {filteredContributors.length === 0 && (
-        <div className="fixed inset-0 flex items-center justify-center p-4 backdrop-blur-sm">
-          <div className="bg-slate-900 border border-slate-700 rounded-2xl p-6 text-center max-w-md">
-            <h1 className="text-xl text-slate-400 font-bold mb-1">No contributors found !</h1>
-            <p className="text-slate-400">Please check your leaderboard configuration.</p>
-          </div>
-        </div>
+         <div className="fixed inset-0 flex items-center justify-center p-4 backdrop-blur-sm">
+            <div className="bg-slate-900 border border-slate-700 rounded-2xl p-6 text-center max-w-md">
+              <h1 className="text-xl text-slate-400 font-bold mb-1">No contributors found !</h1>
+              <p className="text-slate-400">Please check your leaderboard configuration.</p>
+            </div>
+         </div>
       )}
     </div>
   );

--- a/App.tsx
+++ b/App.tsx
@@ -402,6 +402,15 @@ const App: React.FC = () => {
             </div>
          </div>
       )}
+      {/* Display Empty-state message when no contributors are available */}
+      {filteredContributors.length === 0 && (
+        <div className="fixed inset-0 flex items-center justify-center p-4 backdrop-blur-sm">
+          <div className="bg-slate-900 border border-slate-700 rounded-2xl p-6 text-center max-w-md">
+            <h1 className="text-xl text-slate-400 font-bold mb-1">No contributors found !</h1>
+            <p className="text-slate-400">Please check your leaderboard configuration.</p>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/public/data.json
+++ b/public/data.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-01-04T12:07:13.507Z",
+  "timestamp": "2026-01-07T12:07:50.530Z",
   "contributors": [
     {
       "id": "Dnouv",


### PR DESCRIPTION
Fixes #7

### What this PR does
- Adds a clear empty state message when no contributors are available
- Improves user experience by avoiding a blank leaderboard view

### Testing
- Verified empty state appears when no contributors are present
- Verified empty state is hidden when contributor data exists

### Screenshots
**Before** :
<img width="1919" height="942" alt="Screenshot 2026-01-07 202306" src="https://github.com/user-attachments/assets/41000e2d-a300-4bee-83d2-96344542c3da" />

**After** :
<img width="1915" height="879" alt="Screenshot 2026-01-07 210011" src="https://github.com/user-attachments/assets/a96513dc-f15e-4f8b-92a5-bdd7c15f8d3d" />

