### PR TITLE
fix: improve error handling for missing/invalid GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,37 @@ To avoid polluting your commit history when adding users:
 3. Fetch data: `npm run update-data`
 4. Start app: `npm run dev`
 
+## Troubleshooting
+
+### GITHUB_TOKEN Issues
+
+**Error: "GITHUB_TOKEN is missing"**
+- Ensure you have set the `GITHUB_TOKEN` environment variable
+- For local development:
+  - **Linux/macOS**: `export GITHUB_TOKEN="your_token_here"`
+  - **Windows CMD**: `set GITHUB_TOKEN=your_token_here`
+  - **Windows PowerShell**: `$env:GITHUB_TOKEN="your_token_here"`
+- For GitHub Actions: Add `GITHUB_TOKEN` as a repository secret
+
+**Error: "GITHUB_TOKEN appears to be invalid"**
+- Ensure you've copied the **entire** token from GitHub
+- Valid tokens are typically 40+ characters long
+- Fine-grained tokens start with `github_pat_`
+- Classic tokens start with `ghp_`
+
+**Creating a Personal Access Token (PAT)**
+1. Go to [GitHub Token Settings](https://github.com/settings/tokens)
+2. Click "Generate new token (classic)"
+3. Select required scopes:
+   - `repo` (for private repos) or `public_repo` (for public repos only)
+   - `read:org` (to fetch organization repositories)
+4. Copy and save the token securely
+
+**Rate Limit Errors**
+- GitHub API has rate limits (5000 requests/hour for authenticated users)
+- If you hit limits, wait an hour or use a different token
+- Consider reducing the number of tracked repositories
+
 ## Deployment & Artifacts
 
 The `.github/workflows/update-leaderboard.yml` workflow is a complete CI/CD pipeline that:

--- a/scripts/fetch-data.ts
+++ b/scripts/fetch-data.ts
@@ -248,8 +248,47 @@ async function fetchRepoStats(
 }
 
 async function main() {
+  // Validate GITHUB_TOKEN with helpful error messages
   if (!GITHUB_TOKEN) {
-    console.error("Error: GITHUB_TOKEN environment variable is required.");
+    console.error(`
+╔════════════════════════════════════════════════════════════════════════════╗
+║                    ERROR: GITHUB_TOKEN is missing                          ║
+╠════════════════════════════════════════════════════════════════════════════╣
+║ The GITHUB_TOKEN environment variable is required to fetch data from the  ║
+║ GitHub API.                                                                 ║
+║                                                                             ║
+║ To fix this issue:                                                          ║
+║                                                                             ║
+║ 1. Create a GitHub Personal Access Token:                                  ║
+║    → Go to: https://github.com/settings/tokens                             ║
+║    → Click "Generate new token (classic)"                                  ║
+║    → Select scopes: 'repo' and 'read:org'                                  ║
+║    → Copy the generated token                                              ║
+║                                                                             ║
+║ 2. Set the environment variable:                                           ║
+║    • Linux/macOS: export GITHUB_TOKEN="your_token_here"                    ║
+║    • Windows CMD:  set GITHUB_TOKEN=your_token_here                        ║
+║    • Windows PS:   $env:GITHUB_TOKEN="your_token_here"                     ║
+║    • GitHub Actions: Add as a repository secret                            ║
+║                                                                             ║
+║ For more details, see the README.md troubleshooting section.               ║
+╚════════════════════════════════════════════════════════════════════════════╝
+`);
+    process.exit(1);
+  }
+
+  // Validate token format (GitHub tokens are typically 40+ characters)
+  if (GITHUB_TOKEN.length < 40) {
+    console.error(`
+╔════════════════════════════════════════════════════════════════════════════╗
+║                 ERROR: GITHUB_TOKEN appears to be invalid                   ║
+╠════════════════════════════════════════════════════════════════════════════╣
+║ The provided token is too short (${GITHUB_TOKEN.length} characters).                            ║
+║ Valid GitHub tokens are typically 40+ characters long.                      ║
+║                                                                             ║
+║ Please ensure you've copied the entire token from GitHub.                  ║
+╚════════════════════════════════════════════════════════════════════════════╝
+`);
     process.exit(1);
   }
 


### PR DESCRIPTION
- Add comprehensive error message box with step-by-step troubleshooting
- Validate token length (40+ characters)
- Add troubleshooting section to README.md
- Include instructions for all platforms (Linux/macOS, Windows CMD/PS)

Fixes #9